### PR TITLE
Port to Python 3.5

### DIFF
--- a/finvoice/finvoice201.py
+++ b/finvoice/finvoice201.py
@@ -90,7 +90,7 @@ def parsexml_(*args, **kwargs):
 
 try:
     from generatedssuper import GeneratedsSuper
-except ImportError, exp:
+except ImportError as exp:
 
     class GeneratedsSuper(object):
         tzoff_pattern = re_.compile(r'(\+|-)((0\d|1[0-3]):[0-5]\d|14:00)$')
@@ -369,7 +369,7 @@ except ImportError, exp:
             return None
         @classmethod
         def gds_reverse_node_mapping(cls, mapping):
-            return dict(((v, k) for k, v in mapping.iteritems()))
+            return dict(((v, k) for k, v in mapping.items()))
 
 
 #
@@ -410,7 +410,7 @@ def showIndent(outfile, level, pretty_print=True):
 def quote_xml(inStr):
     if not inStr:
         return ''
-    s1 = (isinstance(inStr, basestring) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
@@ -419,7 +419,7 @@ def quote_xml(inStr):
 
 
 def quote_attrib(inStr):
-    s1 = (isinstance(inStr, basestring) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
@@ -18484,7 +18484,7 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 
 
 def usage():
-    print USAGE_TEXT
+    print(USAGE_TEXT)
     sys.exit(1)
 
 
@@ -18540,7 +18540,7 @@ def parseEtree(inFileName, silence=False):
 
 
 def parseString(inString, silence=False):
-    from StringIO import StringIO
+    from io import StringIO
     doc = parsexml_(StringIO(inString))
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)


### PR DESCRIPTION
Some major caveats:
- Only ported `finvoice.finvoice201`, because it is the only part of this thing I'm interested in
- Breaks support of python < 2.6, since those versions do not support the `except Exception as variable` syntax
- More than likely breaks all Python 2.x support because string checks were changed from `isinstance(to_check, basestring)` to `isinstance(to_check, str)`, as the `str, unicode` duality no longer exists in Python 3.5
- `iteritems` calls changed to `items`, which means they will work in Python 2.x but will waste memory.

As such, I've opened this pull request to a separate `py3` branch which we can maybe port stuff to as needed. At some point we may downgrade 2.x from the `master` branch to somewhere else, but right now that seems like a bit of a pain.